### PR TITLE
Update uaa client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "predix-acs-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Node module to check authorization for an action with ACS protecting REST endpoints.  This library does not provide ACS administration functionality.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "predix-uaa-client": "^1.0.0",
+    "predix-uaa-client": "^1.1.0",
     "request": "^2.72.0",
     "url": "^0.11.0"
   }


### PR DESCRIPTION
ACS client needs a UAA token to query ACS.  If multiple concurrent calls arrive and require ACS checks and there is not yet a token cached (or its expired), multiple UAA tokens will be retrieved.
The updated predix-uaa-client addresses this issue and returns only a single token if there are multiple concurrent requests.
