### PR TITLE
Add support for isAuthorizedFor which accepts an object describing th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const config = {
     zoneId: 'your-acs-zone-id'
 };
 const acs = require('predix-acs-client')(config);
-acs.isAuthorized({ method: 'GET', path: 'example' }, 'my-user').then((result) => {
+acs.isAuthorizedFor({ method: 'GET', resourceIdentifier: 'example', subjectIdentifier: 'my-user'}).then((result) => {
      // 'my-user' is authorized to perform the 'GET' action on the 'example' resource.
      console.log('Permission Granted');
 }).catch((err) => {

--- a/test/acs.spec
+++ b/test/acs.spec
@@ -106,7 +106,113 @@ describe('#Configuration', () => {
     });
 });
 
-describe('#Authroization', () => {
+
+describe('#Parameter Checking', () => {
+    it('should reject the promise if a null \'abacRequest\' value is provided', (done) => {
+        // We expect a POST call with the HTTP Verb, Resource being accessed and the user subject
+        let stub = sinon.stub(request, 'post');
+        stub.yields(null, { statusCode: 200 }, testData.stubPermitResponse);
+
+        acs_instance.isAuthorizedFor(null).then((result) => {
+            // Expecting rejected promise
+            done(new Error('Expected the promise to reject the invalid parameter, it instead completed successfully.'));
+        }).catch((err) => {
+            // parameter checking is done first, before the request is built and sent
+            try {
+                expect(stub.calledOnce).to.be.false; // should fail before the request is made
+                done();
+            } catch(fail) {
+                done(fail);
+            }
+        });
+    });
+
+    it('should reject the promise if an undefined \'abacRequest\' value is provided', (done) => {
+        // We expect a POST call with the HTTP Verb, Resource being accessed and the user subject
+        let stub = sinon.stub(request, 'post');
+        stub.yields(null, { statusCode: 200 }, testData.stubPermitResponse);
+
+        const myObject = {};
+
+        acs_instance.isAuthorizedFor(myObject.undefinedProperty).then((result) => {
+            // Expecting rejected promise
+            done(new Error('Expected the promise to reject the invalid parameter, it instead completed successfully.'));
+        }).catch((err) => {
+            // parameter checking is done first, before the request is built and sent
+            try {
+                expect(stub.calledOnce).to.be.false; // should fail before the request is made
+                done();
+            } catch(fail) {
+                done(fail);
+            }
+        });
+    });
+
+    it('should reject the promise if the \'abacRequest\' is missing property \'subjectIdentifier\'', (done) => {
+        // We expect a POST call with the HTTP Verb, Resource being accessed and the user subject
+        let stub = sinon.stub(request, 'post');
+        stub.yields(null, { statusCode: 200 }, testData.stubPermitResponse);
+
+        const abacRequest = {action: 'GET', resourceIdentifier: 'foo'};
+
+        acs_instance.isAuthorizedFor(abacRequest).then((result) => {
+            // Expecting rejected promise
+            done(new Error('Expected the promise to reject due to missing \'abacRequest.subjectIdentifier\' property, it instead completed successfully.'));
+        }).catch((err) => {
+            // parameter checking is done first, before the request is built and sent
+            try {
+                expect(stub.calledOnce).to.be.false; // should fail before the request is made
+                done();
+            } catch(fail) {
+                done(fail);
+            }
+        });
+    });
+
+    it('should reject the promise if the \'abacRequest\' is missing property \'resourceIdentifier\'', (done) => {
+        // We expect a POST call with the HTTP Verb, Resource being accessed and the user subject
+        let stub = sinon.stub(request, 'post');
+        stub.yields(null, { statusCode: 200 }, testData.stubPermitResponse);
+
+        const abacRequest = {action: 'GET', subjectIdentifier: 'foo'};
+
+        acs_instance.isAuthorizedFor(abacRequest).then((result) => {
+            // Expecting rejected promise
+            done(new Error('Expected the promise to reject due to missing \'abacRequest.resourceIdentifier\' property, it instead completed successfully.'));
+        }).catch((err) => {
+            // parameter checking is done first, before the request is built and sent
+            try {
+                expect(stub.calledOnce).to.be.false; // should fail before the request is made
+                done();
+            } catch(fail) {
+                done(fail);
+            }
+        });
+    });
+
+    it('should reject the promise if the \'abacRequest\' is missing property \'action\'', (done) => {
+        // We expect a POST call with the HTTP Verb, Resource being accessed and the user subject
+        let stub = sinon.stub(request, 'post');
+        stub.yields(null, { statusCode: 200 }, testData.stubPermitResponse);
+
+        const abacRequest = {subjectIdentifier: 'foo', resourceIdentifier: 'bar'};
+
+        acs_instance.isAuthorizedFor(abacRequest).then((result) => {
+            // Expecting rejected promise
+            done(new Error('Expected the promise to reject due to missing \'abacRequest.action\' property, it instead completed successfully.'));
+        }).catch((err) => {
+            // parameter checking is done first, before the request is built and sent
+            try {
+                expect(stub.calledOnce).to.be.false; // should fail before the request is made
+                done();
+            } catch(fail) {
+                done(fail);
+            }
+        });
+    });
+});
+
+describe('#Authorization', () => {
     it('should resolve the promise if authorized for the action', (done) => {
         // We expect a POST call with the HTTP Verb, Resource being accessed and the user subject
         let stub = sinon.stub(request, 'post');


### PR DESCRIPTION
…e full resource request

Updated the README.md to show the proper usage of the isAuthorizedFor(...) call
Ensured all tests pass. Fixed typo.

This commit enables the developer to provide their own context for the resource identifier instead of using the request path. It is the responsibility of the developer to ensure the request is built by the server without accepting the resource identifier from the client. To accept theresource identifier from the client would be insecure. The developer may use the request path if leveraging this library for middleware, or they may use context-sensitive identifiers and decouple themselves from the request path.
